### PR TITLE
add coreModule

### DIFF
--- a/app/headers/common.d.ts
+++ b/app/headers/common.d.ts
@@ -8,6 +8,11 @@ declare module 'app/core/config' {
   export default config;
 }
 
+declare module 'app/core/core_module' {
+  var coreModule: any;
+  export default coreModule;
+}
+
 declare module 'lodash' {
   var lodash: any;
   export default lodash;


### PR DESCRIPTION
This adds a stub for core module:

```
declare module 'app/core/core_module' {
  var coreModule: any;
  export default coreModule;
}
```