### PR TITLE
add  $location to PanelCtrl

### DIFF
--- a/app/features/panel/panel_ctrl.ts
+++ b/app/features/panel/panel_ctrl.ts
@@ -11,6 +11,7 @@ export class PanelCtrl {
   editorTabs: any;
   $scope: any;
   $injector: any;
+  $location: any;
   $timeout: any;
   fullscreen: boolean;
   inspector: any;

--- a/app/headers/common.d.ts
+++ b/app/headers/common.d.ts
@@ -127,6 +127,7 @@ declare module 'app/plugins/sdk' {
     editorTabs: any;
     $scope: any;
     $injector: any;
+    $location: any;
     $timeout: any;
     fullscreen: boolean;
     inspector: any;


### PR DESCRIPTION
sdk-mock is out of sync with Grafana.  This patch adds the missing variable $location to the PanelCtrl.  